### PR TITLE
Keep endpoints in Stata rcrplot (see #13)

### DIFF
--- a/stata/rcrplot.ado
+++ b/stata/rcrplot.ado
@@ -51,7 +51,7 @@ program define rcrplot
         local Lambdasym "[{&lambda}{superscript:L},{&lambda}{superscript:H}]"
         local Betasym "[{&beta}{subscript:x}{superscript:L},{&beta}{subscript:x}{superscript:H}]"
     }
-    quietly keep if betax > `xmin' & betax < `xmax' & lambda > `ymin' & lambda < `ymax'
+    quietly keep if betax >= `xmin' & betax <= `xmax' & lambda >= `ymin' & lambda <= `ymax'
 
     twoway line lambda betax if betax < _b[betaxInf]  || ///
         line lambda betax if betax > _b[betaxInf] , lstyle(p1) || ///


### PR DESCRIPTION
The rcrplot code was leaving out any points that were exactly equal to the xrange or yrange boundaries.  Although there usually are no such points, there is no reason to leave htem out if they exist.